### PR TITLE
ID-4183: Leserettar på overstyrt konfig

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,7 @@ COPY docker/proxy/server.xml ${CATALINA_HOME}/conf/server.xml
 RUN mkdir -p /etc/config && chmod 770 /etc/config
 COPY docker/proxy/config /etc/config/eidas-proxy
 COPY docker/proxy/profiles /etc/config/profiles
+RUN chmod -R 770 /etc/config/profiles
 
 COPY docker/overrideProperties.sh ${CATALINA_HOME}/bin/overrideProperties.sh
 RUN chmod 755 ${CATALINA_HOME}/bin/overrideProperties.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ COPY docker/bouncycastle/bcprov-jdk18on-1.78.jar /usr/local/lib/bcprov-jdk18on-1
 COPY docker/proxy/tomcat-setenv.sh ${CATALINA_HOME}/bin/setenv.sh
 COPY docker/proxy/server.xml ${CATALINA_HOME}/conf/server.xml
 
-RUN mkdir -p /etc/config && chmod 770 /etc/config
+RUN mkdir -p /etc/config && chmod 776 /etc/config
 COPY docker/proxy/config /etc/config/eidas-proxy
 COPY docker/proxy/profiles /etc/config/profiles
 RUN chmod -R 770 /etc/config/profiles

--- a/docker/overrideProperties.sh
+++ b/docker/overrideProperties.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# ${ENVIRONMENT} must be configured in idporten-cd in container.env
 
-# copy eidas.xml
-ENV_SOURCE=/etc/config/profiles/${ENVIRONMENT}/
+# NB: ${ENVIRONMENT} must be configured in idporten-cd in container.env
+# Copy environment specific config to default config
+ENV_CONFIG=/etc/config/profiles/${ENVIRONMENT}/
 DEFAULT_CONFIG=/etc/config/eidas-proxy/
-if [ -d "$ENV_SOURCE" ]; then
-    echo "Copy files for environment ${ENVIRONMENT} from $ENV_SOURCE" && ls -lt "$ENV_SOURCE"
-    cp -r -p "$ENV_SOURCE"** "$DEFAULT_CONFIG"
+if [ -d "$ENV_CONFIG" ]; then
+    echo "Copy files for environment ${ENVIRONMENT} from $ENV_CONFIG" && ls -lt "$ENV_CONFIG"
+    cp -r "$ENV_CONFIG"** "$DEFAULT_CONFIG"
 fi

--- a/docker/overrideProperties.sh
+++ b/docker/overrideProperties.sh
@@ -6,5 +6,5 @@ ENV_SOURCE=/etc/config/profiles/${ENVIRONMENT}/
 DEFAULT_CONFIG=/etc/config/eidas-proxy/
 if [ -d "$ENV_SOURCE" ]; then
     echo "Copy files for environment ${ENVIRONMENT} from $ENV_SOURCE" && ls -lt "$ENV_SOURCE"
-    cp -r "$ENV_SOURCE"** "$DEFAULT_CONFIG"
+    cp -r -p "$ENV_SOURCE"** "$DEFAULT_CONFIG"
 fi


### PR DESCRIPTION
fiks dette problemet:
`cp: cannot create regular file '/etc/config/eidas-proxy/eidas.xml': Permission denied

cp: cannot create regular file '/etc/config/eidas-proxy/metadata/MetadataFetcher_Service.properties': Permission denied`