### PR TITLE
ID-4509: Remove HSM security-provider debugging messages

### DIFF
--- a/docker/proxy/config/encryptionConf.xml
+++ b/docker/proxy/config/encryptionConf.xml
@@ -16,10 +16,21 @@
 
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-	<entry key="EncryptTo.CA">true</entry> <!-- demo country CA, not in use in prod-->
 
-	<entry key="EncryptTo.NO">true</entry>
-	<entry key="EncryptTo.SE">true</entry>
-	<entry key="EncryptTo.DK">true</entry>
+    <!--
+     2. When the configuration parameter response.encryption.mandatory is set to true on the
+proxy side, then the settings in encryptionConf.xml are ignored and each response is
+encrypted. When the configuration parameter response.encryption.mandatory is set to true
+on the connector side, then only encrypted responses are allowed for successful authentication.
+     -->
+    <!-- 'response.encryption.mandatory' er default true i eIDAS-koden, så det som står under blir ikkje brukt då
+     sjå doc for versjon X: 'eIDAS-Node and SAML vX pdf' side 15 "3.4.4 Encryption configuration".
+     -->
 
+   <!--
+    <entry key="Encryption.enable">true</entry>
+
+    <entry key="EncryptTo.CA">false</entry>
+
+-->
 </properties>

--- a/docker/proxy/tomcat-setenv.sh
+++ b/docker/proxy/tomcat-setenv.sh
@@ -11,8 +11,8 @@ export JAVA_OPTS="$JAVA_OPTS --add-modules org.bouncycastle.provider"
 #export JAVA_OPTS="$JAVA_OPTS --module-path /var/usrlocal/luna/jsp/LunaProvider.jar"
 #export JAVA_OPTS="$JAVA_OPTS --add-modules Luna"
 
-# Extra debugging HSM
-export JAVA_OPTS="$JAVA_OPTS -Djava.security.debug=sunpkcs11 -Djava.security.debug=pkcs11keystore"
+# Extra debugging HSM, useful when adding new keys and certificates:
+#export JAVA_OPTS="$JAVA_OPTS -Djava.security.debug=sunpkcs11 -Djava.security.debug=pkcs11keystore"
 
 # eidas config
 export EIDAS_PROXY_CONFIG_REPOSITORY="/etc/config/eidas-proxy/"


### PR DESCRIPTION
Also comment out unused encryption config since default is enabled anyway by property `response.encryption.mandatory` in proxy-code and probably in all connecters default as well which then also forces encryption of Assertion values independent of what proxy has configured.