### PR TITLE
ID-5915: legg til catalog-info for prod deploy (INTERNAL-COMMIT)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ Eigar:
 - [ ] Vurdert Manual deploy
 - [ ] Vurdert "internal"
 - [ ] Avhengigheter til andre saker avklart
+- [ ] Evt nye avhengigheter til andre komponenter dokumentert i catalog-info
 - [ ] Har kjørt opp lokalt med docker-compose (bare at den kjører)
 - [ ] Oppdatering/oppretting av regresjonstester er avklart/utført
 - [ ] Har IKKE oppdatert dependabots med mindre dette er en eidas versjons oppdatering

--- a/.github/workflows/call-buildimage.yml
+++ b/.github/workflows/call-buildimage.yml
@@ -9,6 +9,7 @@ on:
       - 'docker-compose.yaml'
       - '*.md'
       - 'LICENSE'
+      - "catalog-info/**"
 
 jobs:
   build-publish-image:

--- a/catalog-info/eidas.yaml
+++ b/catalog-info/eidas.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: eidas-proxy
+  description: eidas-proxy
+  annotations:
+    github.com/project-slug: felleslosninger/eidas-proxy
+spec:
+  type: application
+  owner: team-idporten
+  lifecycle: production
+  system: eidas
+  dependsOn:
+    - resource:default/eidas-redis
+    - component:eidas-idporten-proxy


### PR DESCRIPTION
SAK:
ID-5915

Sjekklister:  
Eigar:

- [x] Vurdert Manual deploy
- [x] Vurdert "internal"
- [x] Avhengigheter til andre saker avklart
- [x] Har kjørt opp lokalt med docker-compose (bare at den kjører)
- [x] Oppdatering/oppretting av regresjonstester er avklart/utført
- [x] Har IKKE oppdatert dependabots med mindre dette er en eidas versjons oppdatering
- [x] Har trimmet .trivyignore (gitt container/tomcat-oppdateringer)

Kodeles:

- [ ] Lesbar kode, nødvendige kommentarer
- [ ] Sak er godt nok forklart/dokumentert
- [ ] Løyser saka
- [ ] Risikovurdering ok
- [ ] Nødvendige regresjonstester er oppdatert/oppretta/planlagt
- [ ] Har oppdatert readme