### PR TITLE
ID-6642: Utgått sertifikat i systest - eidas-proxy (INTERNAL-COMMIT)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,7 @@ CVE-2024-47554 # apache-commons-io fixed in 2.14.0
 CVE-2026-5598 # bouncycastle: BC-JAVA: private key leakage via non-constant fixed in 1.84
 CVE-2025-24970 # io.netty:netty-handler fixed in 4.1.118.Final
 CVE-2026-42583 # Netty Lz4FrameDecoder fixed in 4.1.133.Final
+
+CVE-2026-50010 # netty-handler: Netty: Improper trust manager fixed 4.1.135.Final
+CVE-2026-45416 # netty-handler: DoS in TLS, fixed in 4.1.135.Final
+CVE-2026-44249 # netty-handler: Same as above

--- a/docker/proxy/profiles/systest/SignModule_Service.xml
+++ b/docker/proxy/profiles/systest/SignModule_Service.xml
@@ -26,7 +26,7 @@
 	<entry key="metadata.signature.algorithm">http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1</entry>
 
     <entry key="issuer">CN=norwegian-eidasnode-proxy,OU=ID-porten,O=Digitaliseringsdirektoratet,L=Leikanger,ST=Sogndal,C=NO</entry>
-    <entry key="serialNumber">5A95FCAE5AD728A56919A21F39FF347266795F56</entry>
+    <entry key="serialNumber">5901f3d8dd682e5b</entry>
 
     <entry key="metadata.issuer">CN=eidas-node-metadata,OU=ID-porten,O=Digitaliseringsdirektoratet,L=Leikanger,ST=Sogndal,C=NO</entry>
     <entry key="metadata.serialNumber">5C439B135211720D4F80BB2579F2019173ADCE66</entry>


### PR DESCRIPTION
SAK:
ID-6652 - kun systest

Sjekklister:  
Eigar:

- [x] Vurdert Manual deploy
- [x] Vurdert "internal"
- [x] Avhengigheter til andre saker avklart
- [x] Evt nye avhengigheter til andre komponenter dokumentert i catalog-info
- [x] Har kjørt opp lokalt med docker-compose (bare at den kjører)
- [x] Oppdatering/oppretting av regresjonstester er avklart/utført
- [x] Har IKKE oppdatert dependabots med mindre dette er en eidas versjons oppdatering
- [x] Har trimmet .trivyignore (gitt container/tomcat-oppdateringer)

Kodeles:

- [x] Lesbar kode, nødvendige kommentarer
- [x] Sak er godt nok forklart/dokumentert
- [x] Løyser saka
- [x] Risikovurdering ok
- [x] Nødvendige regresjonstester er oppdatert/oppretta/planlagt
- [x] Har oppdatert readme
